### PR TITLE
chore: Update amplify.yml to fix npm issue

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -5,7 +5,7 @@ frontend:
       commands:
         - nvm install 16
         - nvm use 16
-        - npm install
+        - npm install --legacy-peer-deps
     build:
       commands:
         - CI=false npm run build


### PR DESCRIPTION
Adding `--legacy-peer-deps` to the amplify yaml to allow the stack to be stood up